### PR TITLE
Protect spawns and structures from weird events

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -512,9 +512,9 @@ class Warzone(
         return false
     }
 
-    fun onBlockPlace(player: Player, block: Block): Boolean {
+    fun onBlockPlace(entity: Entity, block: Block): Boolean {
         objectives.values.forEach {
-            if (it.handleBlockPlace(player, block)) {
+            if (it.handleBlockPlace(entity, block)) {
                 return true
             }
         }

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/BlockListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/BlockListener.kt
@@ -9,8 +9,10 @@ import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockBurnEvent
+import org.bukkit.event.block.BlockFromToEvent
 import org.bukkit.event.block.BlockIgniteEvent
 import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.block.BlockSpreadEvent
 
 class BlockListener(val plugin: WarPlus) : Listener {
 
@@ -85,5 +87,19 @@ class BlockListener(val plugin: WarPlus) : Listener {
         val block = event.block
         val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
         event.isCancelled = warzone.onBlockBreak(null, block)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onBlockSpread(event: BlockSpreadEvent) {
+        val block = event.block
+        val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
+        event.isCancelled = warzone.isSpawnBlock(block) || warzone.onBlockBreak(null, block)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onBlockFromTo(event: BlockFromToEvent) {
+        val to = event.toBlock
+        val warzone = plugin.warzoneManager.getWarzoneByLocation(to.location) ?: return
+        event.isCancelled = warzone.isSpawnBlock(to) || warzone.onBlockBreak(null, to)
     }
 }

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
@@ -3,6 +3,7 @@ package com.github.james9909.warplus.listeners
 import com.github.james9909.warplus.WarPlus
 import com.github.james9909.warplus.config.TeamConfigType
 import org.bukkit.entity.Entity
+import org.bukkit.entity.EntityType
 import org.bukkit.entity.FallingBlock
 import org.bukkit.entity.LightningStrike
 import org.bukkit.entity.LivingEntity
@@ -12,6 +13,7 @@ import org.bukkit.entity.TNTPrimed
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityChangeBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityExplodeEvent
@@ -312,9 +314,20 @@ class EntityListener(val plugin: WarPlus) : Listener {
     @EventHandler
     fun onEntityRegainHealthEvent(event: EntityRegainHealthEvent) {
         val player = event.entity as? Player ?: return
-        val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
+        plugin.playerManager.getPlayerInfo(player) ?: return
         if (event.regainReason == EntityRegainHealthEvent.RegainReason.REGEN) {
             event.isCancelled = true
         }
+    }
+
+    @EventHandler
+    fun onEntityChangeBlockEvent(event: EntityChangeBlockEvent) {
+        val block = event.block
+        if (event.entityType != EntityType.FALLING_BLOCK) {
+            return
+        }
+        val location = block.location
+        val warzone = plugin.warzoneManager.getWarzoneByLocation(location) ?: return
+        event.isCancelled = warzone.isSpawnBlock(block) || warzone.onBlockPlace(event.entity, block)
     }
 }

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
@@ -9,6 +9,7 @@ import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryType
+import org.bukkit.event.player.PlayerBucketEmptyEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerItemDamageEvent
 import org.bukkit.event.player.PlayerJoinEvent
@@ -165,5 +166,12 @@ class PlayerListener(val plugin: WarPlus) : Listener {
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
         plugin.inventoryManager.restoreInventoryFromFile(event.player)
+    }
+
+    @EventHandler
+    fun onPlayerBucketEmpty(event: PlayerBucketEmptyEvent) {
+        val block = event.blockClicked
+        val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
+        event.isCancelled = warzone.isSpawnBlock(block) || warzone.onBlockPlace(event.player, block)
     }
 }

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/AbstractObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/AbstractObjective.kt
@@ -5,6 +5,7 @@ import com.github.james9909.warplus.Warzone
 import org.bukkit.Location
 import org.bukkit.block.Block
 import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.entity.Entity
 import org.bukkit.entity.Item
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryAction
@@ -16,7 +17,7 @@ abstract class AbstractObjective(plugin: WarPlus, warzone: Warzone) {
         return false
     }
 
-    open fun handleBlockPlace(player: Player, block: Block): Boolean {
+    open fun handleBlockPlace(entity: Entity, block: Block): Boolean {
         return false
     }
 

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/FlagObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/FlagObjective.kt
@@ -11,6 +11,7 @@ import com.github.james9909.warplus.structures.FlagStructure
 import org.bukkit.Location
 import org.bukkit.block.Block
 import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.entity.Entity
 import org.bukkit.entity.Item
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryAction
@@ -77,8 +78,8 @@ class FlagObjective(
         return stealFlag(player, flagStructure)
     }
 
-    override fun handleBlockPlace(player: Player, block: Block): Boolean {
-        if (flagThieves.containsKey(player)) {
+    override fun handleBlockPlace(entity: Entity, block: Block): Boolean {
+        if (entity is Player && flagThieves.containsKey(entity)) {
             return true
         }
         if (flags.any { it.contains(block.location) }) {

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/MonumentObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/MonumentObjective.kt
@@ -10,6 +10,7 @@ import org.bukkit.Location
 import org.bukkit.attribute.Attribute
 import org.bukkit.block.Block
 import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.entity.Entity
 import org.bukkit.entity.Player
 import kotlin.math.min
 import kotlin.random.Random
@@ -56,13 +57,16 @@ class MonumentObjective(
         return false
     }
 
-    override fun handleBlockPlace(player: Player, block: Block): Boolean {
+    override fun handleBlockPlace(entity: Entity, block: Block): Boolean {
         val monument = monuments.firstOrNull { it.contains(block.location) } ?: return false
         if (block.location != monument.blockLocation) {
             // Can only place into the center block
             return true
         }
-        val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return true
+        if (entity !is Player) {
+            return true
+        }
+        val playerInfo = plugin.playerManager.getPlayerInfo(entity) ?: return true
         if (playerInfo.team.warzone != warzone || block.type != playerInfo.team.kind.material) {
             return true
         }


### PR DESCRIPTION
Weird events include falling sand, flowing water, and fire spreading.