### PR TITLE
Catch `ClassCastException` when updating signs

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -391,10 +391,10 @@ class Warzone(
             if (lives == 1) {
                 broadcast("Team $team's life pool is empty. One more death and they lose the battle!")
             }
+            team.lives -= 1
             team.spawns.forEach {
                 it.updateSign(team)
             }
-            team.lives -= 1
             respawnPlayer(player)
         }
     }

--- a/src/main/kotlin/com/github/james9909/warplus/structures/TeamSpawnStructure.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/structures/TeamSpawnStructure.kt
@@ -13,6 +13,7 @@ import org.bukkit.Material
 import org.bukkit.block.BlockFace
 import org.bukkit.entity.Player
 import org.bukkit.util.Vector
+import java.lang.ClassCastException
 
 enum class SpawnStyle {
     INVISIBLE,
@@ -243,25 +244,34 @@ class TeamSpawnStructure(plugin: WarPlus, origin: Location, val kind: TeamKind, 
     }
 
     override fun postBuild() {
-        signBlock?.apply {
-            type = Material.OAK_SIGN
-            val signData = blockData as org.bukkit.block.data.type.Sign
-            signData.rotation = interCardinalDirection.toBlockFace().oppositeFace
-            blockData = signData
-        }
+        setSignBlock()
     }
 
     fun updateSign(team: WarTeam) {
+        setSignBlock()
         signBlock?.apply {
-            val sign = state as org.bukkit.block.Sign
-            sign.setLine(0, "Team ${kind.name.toLowerCase()}")
-            sign.setLine(1, "${team.size()}/${team.maxPlayers()} players")
-            sign.setLine(2, "${team.score}/${team.maxScore()} points")
-            when (val lives = team.lives) {
-                1 -> sign.setLine(3, "1 life left")
-                else -> sign.setLine(3, "$lives lives left")
-            }
-            sign.update(true)
+            try {
+                val sign = state as org.bukkit.block.Sign
+                sign.setLine(0, "Team ${kind.name.toLowerCase()}")
+                sign.setLine(1, "${team.size()}/${team.maxPlayers()} players")
+                sign.setLine(2, "${team.score}/${team.maxScore()} points")
+                when (val lives = team.lives) {
+                    1 -> sign.setLine(3, "1 life left")
+                    else -> sign.setLine(3, "$lives lives left")
+                }
+                sign.update(true)
+            } catch (ignored: ClassCastException) { /* no-op */ }
+        }
+    }
+
+    private fun setSignBlock() {
+        signBlock?.apply {
+            try {
+                type = Material.OAK_SIGN
+                val signData = blockData as org.bukkit.block.data.type.Sign
+                signData.rotation = interCardinalDirection.toBlockFace().oppositeFace
+                blockData = signData
+            } catch (ignored: ClassCastException) { /* no-op */ }
         }
     }
 

--- a/src/main/kotlin/com/github/james9909/warplus/structures/WarzonePortalStructure.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/structures/WarzonePortalStructure.kt
@@ -34,32 +34,41 @@ class WarzonePortalStructure(
     }
 
     override fun postBuild() {
-        signBlock.type = Material.OAK_WALL_SIGN
-        val signData = signBlock.blockData as Directional
-        signData.facing = orientation.back.toBlockFace()
-        signBlock.blockData = signData
+        setSignBlock()
         updateBlocks()
     }
 
     fun updateBlocks() {
-        val block = signBlock.state
-        val sign = block as org.bukkit.block.Sign
-        sign.setLine(0, "Warzone")
-        sign.setLine(1, warzone.name)
-        sign.setLine(2, "${warzone.numPlayers()}/${warzone.maxPlayers()}")
-        sign.setLine(3, "${warzone.teams.size} teams")
-        block.update(true)
-        if (warzone.numPlayers() > 0) {
-            origin.block
-                .getRelative(orientation.left.toBlockFace())
-                .getRelative(BlockFace.UP, 2)
-                .type = Material.REDSTONE_BLOCK
-            origin.block
-                .getRelative(orientation.right.toBlockFace())
-                .getRelative(BlockFace.UP, 2)
-                .type = Material.REDSTONE_BLOCK
-        } else {
-            restoreVolume()
-        }
+        setSignBlock()
+        try {
+            val block = signBlock.state
+            val sign = block as org.bukkit.block.Sign
+            sign.setLine(0, "Warzone")
+            sign.setLine(1, warzone.name)
+            sign.setLine(2, "${warzone.numPlayers()}/${warzone.maxPlayers()}")
+            sign.setLine(3, "${warzone.teams.size} teams")
+            block.update(true)
+            if (warzone.numPlayers() > 0) {
+                origin.block
+                    .getRelative(orientation.left.toBlockFace())
+                    .getRelative(BlockFace.UP, 2)
+                    .type = Material.REDSTONE_BLOCK
+                origin.block
+                    .getRelative(orientation.right.toBlockFace())
+                    .getRelative(BlockFace.UP, 2)
+                    .type = Material.REDSTONE_BLOCK
+            } else {
+                restoreVolume()
+            }
+        } catch (ignored: ClassCastException) { /* no-op */ }
+    }
+
+    private fun setSignBlock() {
+        try {
+            signBlock.type = Material.OAK_WALL_SIGN
+            val signData = signBlock.blockData as Directional
+            signData.facing = orientation.back.toBlockFace()
+            signBlock.blockData = signData
+        } catch (ignored: ClassCastException) { /* no-op */ }
     }
 }


### PR DESCRIPTION
Fixes an issue where on some rare occurrence, the sign block cannot be cast as a `Sign`.

[Sun, 4. Oct 2020 17:23:31 PDT WARN] Caused by: java.lang.ClassCastException: org.bukkit.craftbukkit.v1_15_R1.block.CraftBlockState cannot be cast to org.bukkit.block.Sign