### PR TITLE
Always register MS event listener

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
@@ -160,7 +160,9 @@ class WarPlus : JavaPlugin {
         pluginManager.registerEvents(BlockListener(this), this)
         pluginManager.registerEvents(EntityListener(this), this)
         pluginManager.registerEvents(PlayerListener(this), this)
-        pluginManager.registerEvents(MagicSpellsListener(this), this)
+        if (server.name != "ServerMock") {
+            pluginManager.registerEvents(MagicSpellsListener(this), this)
+        }
     }
 
     private fun setupEconomy() {

--- a/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
@@ -129,7 +129,6 @@ class WarPlus : JavaPlugin {
         getCommand(WARPLUS_BASE_COMMAND)?.setExecutor(CommandHandler(this))
         setupRunnables()
         setupEconomy()
-        setupMagicSpells()
         loaded.set(true)
     }
 
@@ -161,6 +160,7 @@ class WarPlus : JavaPlugin {
         pluginManager.registerEvents(BlockListener(this), this)
         pluginManager.registerEvents(EntityListener(this), this)
         pluginManager.registerEvents(PlayerListener(this), this)
+        pluginManager.registerEvents(MagicSpellsListener(this), this)
     }
 
     private fun setupEconomy() {
@@ -175,14 +175,6 @@ class WarPlus : JavaPlugin {
         } else {
             logger.info("Vault found, but no economy plugin was detected. Economy rewards will be disabled")
         }
-    }
-
-    private fun setupMagicSpells() {
-        if (!hasPlugin("MagicSpells")) {
-            return
-        }
-        logger.info("MagicSpells found, enabling integration")
-        server.pluginManager.registerEvents(MagicSpellsListener(this), this)
     }
 
     private fun setupDatabase() {

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
@@ -65,7 +65,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
         when (damager) {
             is Player -> handlePlayerDamageByPlayer(event, defender, damager, canFriendlyFire)
             is LivingEntity -> handlePlayerDamageByMonster(event, defender, damager)
-            is FallingBlock, is LightningStrike, is Firework, null -> handleNaturalPlayerDamage(event, defender)
+            is FallingBlock, is LightningStrike, is Firework, is TNTPrimed, null -> handleNaturalPlayerDamage(event, defender)
             else -> {
                 plugin.logger.severe("Failed to explicitly handle damage event:\nevent: $event\ndamager: $damager")
                 handleNaturalPlayerDamage(event, defender)

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/MagicSpellsListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/MagicSpellsListener.kt
@@ -66,11 +66,7 @@ class MagicSpellsListener(val plugin: WarPlus) : Listener {
             return
         }
 
-        if (targetInfo.inSpawn) {
-            event.isCancelled = true
-            return
-        }
-        if (casterInfo.inSpawn) {
+        if (targetInfo.inSpawn || casterInfo.inSpawn) {
             event.isCancelled = true
             return
         }
@@ -79,13 +75,11 @@ class MagicSpellsListener(val plugin: WarPlus) : Listener {
             // Only allow beneficial spells to target teammates
             if (!spell.isBeneficial) {
                 event.isCancelled = true
-                return
             }
         } else {
             // Only allow harmful spells to target enemies
             if (spell.isBeneficial) {
                 event.isCancelled = true
-                return
             }
         }
     }


### PR DESCRIPTION
There seems to be an issue where MS may load after us, so MS is not correctly detected. This kind of lazy loading isn't really necessary, so let's just register the events all the time.