### PR TITLE
Remove unnecessary synchronization

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
@@ -147,7 +147,7 @@ class WarPlus : JavaPlugin {
     fun hasPlugin(plugin: String): Boolean = server.pluginManager.isPluginEnabled(plugin)
 
     private fun setupRunnables() {
-        usr.runTaskTimerAsynchronously(this, 0, UPDATE_SCOREBOARD_TICKS)
+        usr.runTaskTimer(this, 0, UPDATE_SCOREBOARD_TICKS)
     }
 
     private fun cancelRunnables() {

--- a/src/main/kotlin/com/github/james9909/warplus/WarTeam.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarTeam.kt
@@ -131,7 +131,6 @@ class WarTeam(
         return warzone.resolveClasses()
     }
 
-    @Synchronized
     fun addPoint() {
         score += 1
         spawns.forEach { it.updateSign(this) }

--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -55,7 +55,6 @@ import org.bukkit.inventory.ItemStack
 import java.io.File
 import java.math.RoundingMode
 import java.text.DecimalFormat
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.sqrt
@@ -79,7 +78,7 @@ class Warzone(
     private val portals: HashMap<String, WarzonePortalStructure> = hashMapOf()
 ) {
     var state = WarzoneState.IDLING
-    val teams = ConcurrentHashMap<TeamKind, WarTeam>()
+    val teams = HashMap<TeamKind, WarTeam>()
     private val spectators = HashSet<Player>()
     private val configPath = "${plugin.dataFolder.absolutePath}/warzone-$name.yml"
     private val volumeFolder = "${plugin.dataFolder.absolutePath}/volumes/warzones"
@@ -129,7 +128,7 @@ class Warzone(
             removeEntities()
         }
         if (plugin.hasPlugin("FastAsyncWorldEdit")) {
-            plugin.server.scheduler.runTaskLaterAsynchronously(plugin, { _ ->
+            plugin.server.scheduler.runTaskLater(plugin, { _ ->
                 state = oldState
             }, 40L)
         }
@@ -147,7 +146,6 @@ class Warzone(
         }
     }
 
-    @Synchronized
     fun removePlayer(player: Player, team: WarTeam, showLeaveMessage: Boolean = true) {
         team.removePlayer(player)
         removePlayer(player)
@@ -183,7 +181,6 @@ class Warzone(
         }
     }
 
-    @Synchronized
     fun addPlayer(player: Player): Boolean {
         if (numPlayers() >= maxPlayers()) {
             plugin.playerManager.sendMessage(player, Message.TOO_MANY_PLAYERS)
@@ -201,7 +198,6 @@ class Warzone(
         return false
     }
 
-    @Synchronized
     private fun addPlayer(player: Player, team: WarTeam): Boolean {
         val joinEvent = WarzoneJoinEvent(player, this)
         plugin.server.pluginManager.callEvent(joinEvent)
@@ -374,7 +370,6 @@ class Warzone(
         return Ok(Unit)
     }
 
-    @Synchronized
     private fun handleDeath(player: Player, entity: Entity?, cause: DamageCause) {
         val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
         val deathEvent = WarzonePlayerDeathEvent(player, this, entity, cause)

--- a/src/main/kotlin/com/github/james9909/warplus/managers/InventoryManager.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/managers/InventoryManager.kt
@@ -6,11 +6,10 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import java.io.File
 import java.lang.ClassCastException
-import java.util.concurrent.ConcurrentHashMap
 
 class InventoryManager(val plugin: WarPlus) {
     private val baseDirectory = File(plugin.dataFolder, "inventories")
-    private val players = ConcurrentHashMap<Player, Array<ItemStack?>>()
+    private val players = HashMap<Player, Array<ItemStack?>>()
 
     fun saveInventory(player: Player) {
         val inventoryContents = player.inventory.contents

--- a/src/main/kotlin/com/github/james9909/warplus/managers/PlayerManager.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/managers/PlayerManager.kt
@@ -12,7 +12,6 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.permissions.PermissionAttachment
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
 sealed class WarParticipant {
     data class Player(
@@ -27,8 +26,8 @@ sealed class WarParticipant {
 }
 
 class PlayerManager(val plugin: WarPlus) {
-    private val players = ConcurrentHashMap<Player, WarParticipant>()
-    private val permissions = ConcurrentHashMap<UUID, PermissionAttachment>()
+    private val players = HashMap<Player, WarParticipant>()
+    private val permissions = HashMap<UUID, PermissionAttachment>()
     private val chatPrefix: String
 
     init {

--- a/src/main/kotlin/com/github/james9909/warplus/util/WarScoreboard.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/util/WarScoreboard.kt
@@ -8,10 +8,8 @@ import org.bukkit.ChatColor
 import org.bukkit.entity.Player
 import org.bukkit.scoreboard.DisplaySlot
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
-val PLAYER_SCOREBOARDS: MutableMap<UUID, WarScoreboard> = ConcurrentHashMap()
-private val updating: MutableMap<UUID, Boolean> = ConcurrentHashMap()
+val PLAYER_SCOREBOARDS: MutableMap<UUID, WarScoreboard> = HashMap()
 
 class WarScoreboard(val player: Player, private val zone: Warzone) {
     val scoreboard = Bukkit.getScoreboardManager()!!.getNewScoreboard()
@@ -62,10 +60,6 @@ class WarScoreboard(val player: Player, private val zone: Warzone) {
     }
 
     fun update() {
-        if (updating.getOrDefault(player.uniqueId, false)) {
-            return
-        }
-        updating[player.uniqueId] = true
         this.lines = 20
 
         addText("")
@@ -84,8 +78,6 @@ class WarScoreboard(val player: Player, private val zone: Warzone) {
         if (flash) {
             lastFlash = now
         }
-
-        updating[player.uniqueId] = false
     }
 
     private fun addText(text: String) {
@@ -142,7 +134,6 @@ class WarScoreboard(val player: Player, private val zone: Warzone) {
 
         fun removeScoreboard(player: Player) {
             PLAYER_SCOREBOARDS.remove(player.uniqueId)
-            updating.remove(player.uniqueId)
             player.scoreboard = Bukkit.getScoreboardManager()!!.getNewScoreboard()
         }
 


### PR DESCRIPTION
Since we aren't using an asynchronous events/tasks, we don't need to use synchronization primitives to ensure correctness.