### PR TITLE
Prevent FAWE pastes from placing blocks onto protected warzone areas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,9 @@ repositories {
     jcenter()
     maven { url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
     maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
-    maven { url = "http://maven.sk89q.com/repo/" }
     maven { url = "https://dl.bintray.com/michaelbull/maven" }
     maven { url = "https://jitpack.io" }
+    maven { url = uri("https://mvn.intellectualsites.com/content/repositories/releases/") } // FAWE
     flatDir {
         dirs "lib"
     }
@@ -59,7 +59,7 @@ dependencies {
     compile "mysql:mysql-connector-java:5.1.13"
     compile "com.zaxxer:HikariCP:3.4.5"
     compileOnly ":MagicSpells-4.0-Beta-7"
-    compileOnly "com.sk89q.worldedit:worldedit-bukkit:7.0.0-SNAPSHOT"
+    compileOnly "com.intellectualsites.fawe:FAWE-Bukkit:1.16-462"
     compileOnly "org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT"
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
     testCompile "org.junit.jupiter:junit-jupiter:5.4.2"

--- a/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
@@ -8,6 +8,7 @@ import com.github.james9909.warplus.config.WarzoneConfigType
 import com.github.james9909.warplus.extensions.get
 import com.github.james9909.warplus.listeners.BlockListener
 import com.github.james9909.warplus.listeners.EntityListener
+import com.github.james9909.warplus.listeners.FaweListener
 import com.github.james9909.warplus.listeners.MagicSpellsListener
 import com.github.james9909.warplus.listeners.PlayerListener
 import com.github.james9909.warplus.managers.ClassManager
@@ -19,6 +20,7 @@ import com.github.james9909.warplus.managers.WarzoneManager
 import com.github.james9909.warplus.runnable.UpdateScoreboardRunnable
 import com.github.james9909.warplus.sql.MySqlConnectionFactory
 import com.github.james9909.warplus.sql.SqliteConnectionFactory
+import com.sk89q.worldedit.WorldEdit
 import net.milkbowl.vault.economy.Economy
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.event.HandlerList
@@ -27,7 +29,6 @@ import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.plugin.java.JavaPluginLoader
 import org.yaml.snakeyaml.error.YAMLException
 import java.io.File
-import java.lang.IllegalArgumentException
 import java.util.concurrent.atomic.AtomicBoolean
 
 const val WARPLUS_BASE_COMMAND = "wp"
@@ -75,6 +76,7 @@ class WarPlus : JavaPlugin {
     private var databaseManager: DatabaseManager? = null // late initialization
     private var usr = UpdateScoreboardRunnable(this)
     private val allowedCommands = mutableSetOf<String>()
+    private var worldEditSubscriber: FaweListener? = null // late initialization
     var loaded = AtomicBoolean()
         private set
     var economy: Economy? = null
@@ -146,6 +148,9 @@ class WarPlus : JavaPlugin {
         databaseManager?.close()
         itemNameManager.clear()
         cancelRunnables()
+        if (server.name != "ServerMock") {
+            WorldEdit.getInstance().eventBus.unregister(worldEditSubscriber)
+        }
         loaded.set(false)
     }
 
@@ -167,6 +172,8 @@ class WarPlus : JavaPlugin {
         pluginManager.registerEvents(PlayerListener(this), this)
         if (server.name != "ServerMock") {
             pluginManager.registerEvents(MagicSpellsListener(this), this)
+            worldEditSubscriber = FaweListener(this)
+            WorldEdit.getInstance().eventBus.register(worldEditSubscriber)
         }
     }
 

--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -134,11 +134,13 @@ class Warzone(
             removeEntities()
         }
         if (plugin.hasPlugin("FastAsyncWorldEdit")) {
-            plugin.server.scheduler.runTaskLater(plugin, { _ ->
+            plugin.server.scheduler.runTaskAsynchronously(plugin) { _ ->
+                val start = System.currentTimeMillis()
+                restoreVolume()
+                println("Paste time: ${System.currentTimeMillis() - start}")
                 state = oldState
-            }, 40L)
+            }
         }
-        restoreVolume()
         teams.values.forEach { team ->
             team.resetAttributes(resetTeamScores)
             team.resetSpawns()

--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -137,7 +137,7 @@ class Warzone(
             plugin.server.scheduler.runTaskAsynchronously(plugin) { _ ->
                 val start = System.currentTimeMillis()
                 restoreVolume()
-                println("Paste time: ${System.currentTimeMillis() - start}")
+                plugin.logger.info("Warzone volume reset took ${System.currentTimeMillis() - start} ms")
                 state = oldState
             }
         }

--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -15,9 +15,9 @@ import com.github.james9909.warplus.extensions.format
 import com.github.james9909.warplus.extensions.get
 import com.github.james9909.warplus.extensions.pairs
 import com.github.james9909.warplus.objectives.CapturePointObjective
-import com.github.james9909.warplus.objectives.Objective
 import com.github.james9909.warplus.objectives.FlagObjective
 import com.github.james9909.warplus.objectives.MonumentObjective
+import com.github.james9909.warplus.objectives.Objective
 import com.github.james9909.warplus.region.Region
 import com.github.james9909.warplus.structures.CapturePointStructure
 import com.github.james9909.warplus.structures.FlagStructure
@@ -351,8 +351,8 @@ class Warzone(
     }
 
     fun saveVolume(): Result<Unit, WarError> {
-        if (!plugin.hasPlugin("WorldEdit")) {
-            return Err(WorldEditError("WorldEdit is not loaded"))
+        if (!plugin.hasPlugin("FastAsyncWorldEdit")) {
+            return Err(WorldEditError("FastAsyncWorldEdit is not loaded"))
         }
 
         val (minX, minY, minZ) = region.getMinimumPoint()
@@ -371,8 +371,8 @@ class Warzone(
     }
 
     fun restoreVolume(): Result<Unit, WarError> {
-        if (!plugin.hasPlugin("WorldEdit")) {
-            return Err(WorldEditError("WorldEdit is not loaded"))
+        if (!plugin.hasPlugin("FastAsyncWorldEdit")) {
+            return Err(WorldEditError("FastAsyncWorldEdit is not loaded"))
         }
 
         val clipboard = loadSchematic(volumePath)
@@ -589,7 +589,7 @@ class Warzone(
         return false
     }
 
-    fun onBlockPlace(entity: Entity, block: Block): Boolean {
+    fun onBlockPlace(entity: Entity?, block: Block): Boolean {
         objectives.values.forEach {
             if (it.handleBlockPlace(entity, block)) {
                 return true

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/WorldEditListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/WorldEditListener.kt
@@ -1,0 +1,44 @@
+package com.github.james9909.warplus.listeners
+
+import com.github.james9909.warplus.WarPlus
+import com.github.james9909.warplus.WarzoneState
+import com.sk89q.worldedit.bukkit.BukkitAdapter
+import com.sk89q.worldedit.event.extent.EditSessionEvent
+import com.sk89q.worldedit.extent.MaskingExtent
+import com.sk89q.worldedit.function.mask.Mask
+import com.sk89q.worldedit.math.BlockVector3
+import com.sk89q.worldedit.util.eventbus.Subscribe
+import org.bukkit.Location
+import org.bukkit.World
+
+class WarzoneMask(private val plugin: WarPlus, private val world: World) : Mask {
+    override fun test(vector: BlockVector3): Boolean {
+        val location = Location(world, vector.x.toDouble(), vector.y.toDouble(), vector.z.toDouble())
+        val warzone = plugin.warzoneManager.getWarzones().firstOrNull { warzone ->
+            warzone.contains(location)
+        } ?: return true
+        if (warzone.state == WarzoneState.RUNNING) {
+            // We only care about potentially malicious pastes if the warzone is currently running
+            val realBlock = world.getBlockAt(location)
+            return !warzone.isSpawnBlock(realBlock) && !warzone.onBlockPlace(null, realBlock)
+        }
+        return true
+    }
+
+    override fun copy(): Mask = WarzoneMask(plugin, world)
+}
+
+class FaweListener(private val plugin: WarPlus) {
+    @Subscribe
+    fun onEditSessionEvent(event: EditSessionEvent) {
+        val world = event.world
+        if (world != null) {
+            event.extent.addProcessor(
+                MaskingExtent(
+                    event.extent,
+                    WarzoneMask(plugin, BukkitAdapter.adapt(world))
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/github/james9909/warplus/managers/WarzoneManager.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/managers/WarzoneManager.kt
@@ -175,7 +175,7 @@ class WarzoneManager(val plugin: WarPlus) {
                 settings = cascadingTeamSettings,
                 classes = classes
             )
-            if (plugin.hasPlugin("WorldEdit")) {
+            if (plugin.hasPlugin("FastAsyncWorldEdit")) {
                 team.resetSpawns()
             }
             teams.add(team)
@@ -198,7 +198,7 @@ class WarzoneManager(val plugin: WarPlus) {
                 else -> null
             }
             if (objective != null) {
-                if (plugin.hasPlugin("WorldEdit")) {
+                if (plugin.hasPlugin("FastAsyncWorldEdit")) {
                     objective.reset()
                 }
                 warzone.objectives[objective.name] = objective
@@ -218,7 +218,7 @@ class WarzoneManager(val plugin: WarPlus) {
             val portal = WarzonePortalStructure(
                 plugin, origin, portalName, warzone
             )
-            if (plugin.hasPlugin("WorldEdit")) {
+            if (plugin.hasPlugin("FastAsyncWorldEdit")) {
                 portal.build()
             }
             warzone.addPortal(portal)

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/CapturePointObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/CapturePointObjective.kt
@@ -44,7 +44,7 @@ class CapturePointObjective(
         return capturePoints.firstOrNull { it.contains(block.location) } != null
     }
 
-    override fun handleBlockPlace(entity: Entity, block: Block): Boolean {
+    override fun handleBlockPlace(entity: Entity?, block: Block): Boolean {
         return capturePoints.firstOrNull { it.contains(block.location) } != null
     }
 

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/FlagObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/FlagObjective.kt
@@ -78,14 +78,11 @@ class FlagObjective(
         return stealFlag(player, flagStructure)
     }
 
-    override fun handleBlockPlace(entity: Entity, block: Block): Boolean {
+    override fun handleBlockPlace(entity: Entity?, block: Block): Boolean {
         if (entity is Player && flagThieves.containsKey(entity)) {
             return true
         }
-        if (flags.any { it.contains(block.location) }) {
-            return true
-        }
-        return false
+        return flags.any { it.contains(block.location) }
     }
 
     override fun handleItemPickup(player: Player, item: Item): Boolean = flagThieves.containsKey(player)

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/MonumentObjective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/MonumentObjective.kt
@@ -57,7 +57,7 @@ class MonumentObjective(
         return false
     }
 
-    override fun handleBlockPlace(entity: Entity, block: Block): Boolean {
+    override fun handleBlockPlace(entity: Entity?, block: Block): Boolean {
         val monument = monuments.firstOrNull { it.contains(block.location) } ?: return false
         if (block.location != monument.blockLocation) {
             // Can only place into the center block

--- a/src/main/kotlin/com/github/james9909/warplus/objectives/Objective.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/objectives/Objective.kt
@@ -17,7 +17,7 @@ abstract class Objective(plugin: WarPlus, warzone: Warzone) {
         return false
     }
 
-    open fun handleBlockPlace(entity: Entity, block: Block): Boolean {
+    open fun handleBlockPlace(entity: Entity?, block: Block): Boolean {
         return false
     }
 

--- a/src/main/kotlin/com/github/james9909/warplus/util/WorldEditCompat.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/util/WorldEditCompat.kt
@@ -1,5 +1,6 @@
 package com.github.james9909.warplus.util
 
+import com.boydti.fawe.util.EditSessionBuilder
 import com.github.james9909.warplus.FileError
 import com.github.james9909.warplus.InvalidSchematicError
 import com.github.james9909.warplus.WarError
@@ -10,6 +11,7 @@ import com.github.michaelbull.result.Result
 import com.sk89q.worldedit.WorldEdit
 import com.sk89q.worldedit.WorldEditException
 import com.sk89q.worldedit.bukkit.BukkitAdapter
+import com.sk89q.worldedit.bukkit.BukkitWorld
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard
 import com.sk89q.worldedit.extent.clipboard.Clipboard
 import com.sk89q.worldedit.extent.clipboard.io.BuiltInClipboardFormat
@@ -43,12 +45,17 @@ fun loadSchematic(fileName: String): Result<Clipboard, WarError> {
 
 fun pasteSchematic(clipboard: Clipboard, location: Location, ignoreAirBlocks: Boolean): Result<Unit, WarError> {
     try {
-        val editSession =
-            WorldEdit.getInstance().editSessionFactory.getEditSession(BukkitAdapter.adapt(location.world), -1)
-        editSession.use {
+        val session = EditSessionBuilder(BukkitWorld(location.world))
+            .autoQueue(true)
+            .fastmode(true)
+            .combineStages(true)
+            .checkMemory(false)
+            .limitUnlimited()
+            .build()
+        session.use {
             val clipboardHolder = ClipboardHolder(clipboard)
             val operation = clipboardHolder
-                .createPaste(editSession)
+                .createPaste(session)
                 .to(BlockVector3.at(location.blockX, location.blockY, location.blockZ))
                 .ignoreAirBlocks(ignoreAirBlocks)
                 .build()

--- a/src/main/kotlin/com/github/james9909/warplus/util/WorldEditCompat.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/util/WorldEditCompat.kt
@@ -10,7 +10,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.sk89q.worldedit.WorldEdit
 import com.sk89q.worldedit.WorldEditException
-import com.sk89q.worldedit.bukkit.BukkitAdapter
 import com.sk89q.worldedit.bukkit.BukkitWorld
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard
 import com.sk89q.worldedit.extent.clipboard.Clipboard

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: com.github.james9909.warplus.WarPlus
 api-version: 1.16
 version: 0.1.0
 author: james9909
-softdepend: [MagicSpells, Vault, WorldEdit]
+softdepend: [MagicSpells, Vault, FastAsyncWorldEdit]
 depend: []
 permissions:
   warplus.admin:


### PR DESCRIPTION
We can now prevent warzone players from pasting schematics into protected regions, such as objectives and spawns. However, we now depend on FAWE-specific functionality, breaking compatibility with WorldEdit. Given the nature of this plugin, it seems fair to require FAWE, so we can visit WE compatibility at a later date.