### PR TITLE
Remove navy team

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/WarTeam.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarTeam.kt
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player
 
 enum class TeamKind(val material: Material, val chatColor: ChatColor) {
     BLACK(Material.BLACK_WOOL, ChatColor.BLACK),
-    BLUE(Material.LIGHT_BLUE_WOOL, ChatColor.BLUE),
+    BLUE(Material.BLUE_WOOL, ChatColor.BLUE),
     BROWN(Material.BROWN_WOOL, ChatColor.DARK_RED),
     DARKGREEN(Material.GREEN_WOOL, ChatColor.DARK_GREEN),
     DIAMOND(Material.CYAN_WOOL, ChatColor.DARK_AQUA),
@@ -21,7 +21,6 @@ enum class TeamKind(val material: Material, val chatColor: ChatColor) {
     GREEN(Material.GREEN_WOOL, ChatColor.GREEN),
     IRON(Material.LIGHT_GRAY_WOOL, ChatColor.GRAY),
     MAGENTA(Material.MAGENTA_WOOL, ChatColor.LIGHT_PURPLE),
-    NAVY(Material.BLUE_WOOL, ChatColor.DARK_BLUE),
     ORANGE(Material.ORANGE_WOOL, ChatColor.GOLD),
     PINK(Material.PINK_WOOL, ChatColor.LIGHT_PURPLE),
     PURPLE(Material.PURPLE_WOOL, ChatColor.DARK_PURPLE),

--- a/src/test/kotlin/com/github/james9909/warplus/extensions/ConfigurationSectionUtilsTest.kt
+++ b/src/test/kotlin/com/github/james9909/warplus/extensions/ConfigurationSectionUtilsTest.kt
@@ -50,9 +50,9 @@ class ConfigurationSectionUtilsTest {
     fun `get() correctly retrieves default ConfigKey values for enums`() {
         val configFile = File("src/test/resources/fixtures/config/warzone-valid.yml")
         val config = YamlConfiguration.loadConfiguration(configFile)
-        val navyConfig = config.getConfigurationSection("teams.navy.settings")
-        require(navyConfig != null)
-        assert(navyConfig.get(TeamConfigType.SPAWN_STYLE) == SpawnStyle.SMALL)
+        val blueConfig = config.getConfigurationSection("teams.blue.settings")
+        require(blueConfig != null)
+        assert(blueConfig.get(TeamConfigType.SPAWN_STYLE) == SpawnStyle.SMALL)
 
         val redConfig = config.getConfigurationSection("teams.red.settings")
         require(redConfig != null)

--- a/src/test/kotlin/com/github/james9909/warplus/managers/WarzoneManagerTest.kt
+++ b/src/test/kotlin/com/github/james9909/warplus/managers/WarzoneManagerTest.kt
@@ -47,8 +47,8 @@ class WarzoneManagerTest {
         assert(warzone.name == "valid")
         assert(warzone.isEnabled())
         assert(warzone.teams.size == 2)
-        warzone.teams[TeamKind.NAVY]?.apply {
-            assert(kind == TeamKind.NAVY)
+        warzone.teams[TeamKind.BLUE]?.apply {
+            assert(kind == TeamKind.BLUE)
             assert(spawns.size == 1)
             spawns[0].apply {
                 assert(origin.x == 50.0)
@@ -56,7 +56,7 @@ class WarzoneManagerTest {
                 assert(origin.z == 50.0)
                 assert(origin.world?.name == "flat")
             }
-        } ?: fail("Navy team is null")
+        } ?: fail("Blue team is null")
 
         warzone.teams[TeamKind.RED]?.apply {
             assert(kind == TeamKind.RED)
@@ -76,13 +76,13 @@ class WarzoneManagerTest {
         require(flagObjective != null)
         assert(flagObjective.flags.size == 2)
         flagObjective.flags[0].apply {
-            assert(kind == TeamKind.NAVY)
+            assert(kind == TeamKind.BLUE)
             assert(origin.x == 60.0)
             assert(origin.y == 50.0)
             assert(origin.z == 40.0)
         }
         flagObjective.flags[1].apply {
-            assert(kind == TeamKind.NAVY)
+            assert(kind == TeamKind.RED)
             assert(origin.x == 40.0)
             assert(origin.y == 50.0)
             assert(origin.z == 60.0)
@@ -135,12 +135,12 @@ class WarzoneManagerTest {
             assert(settings.get(TeamConfigType.MAX_SCORE) == 5)
         } ?: fail("Team red is null")
 
-        warzone.teams[TeamKind.NAVY]?.apply {
+        warzone.teams[TeamKind.BLUE]?.apply {
             assert(settings.get(TeamConfigType.LIVES) == 30)
             assert(settings.get(TeamConfigType.SPAWN_STYLE) == SpawnStyle.SMALL)
             assert(settings.get(TeamConfigType.MIN_PLAYERS) == 1)
             assert(settings.get(TeamConfigType.MAX_PLAYERS) == 20)
             assert(settings.get(TeamConfigType.MAX_SCORE) == 5)
-        } ?: fail("Team navy is null")
+        } ?: fail("Team blue is null")
     }
 }

--- a/src/test/resources/fixtures/config/warzone-valid.yml
+++ b/src/test/resources/fixtures/config/warzone-valid.yml
@@ -14,7 +14,7 @@ team-settings:
   min-players: 1
   max-players: 20
 teams:
-  navy:
+  blue:
     settings:
       lives: 30
       spawn-style: small
@@ -34,9 +34,9 @@ objectives:
   flags:
     locations:
     - origin: flat:60.0,50.0,40.0,0.0,0.0
-      team: navy
+      team: blue
     - origin: flat:40.0,50.0,60.0,0.0,0.0
-      team: navy
+      team: red
   monuments:
     locations:
     - name: Monument1


### PR DESCRIPTION
Navy is too dark to easily read, so it's being fully replaced with blue.