### PR TITLE
Prevent cancelled MS events from being sent to `MagicSpellsListener`

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/listeners/MagicSpellsListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/MagicSpellsListener.kt
@@ -15,6 +15,11 @@ import org.bukkit.entity.Player
 class MagicSpellsListener(val plugin: WarPlus) : Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onSpellCast(event: SpellCastEvent) {
+        if (event.isCancelled) {
+            // Apparently we might be receiving a cancelled event despite not opting into
+            // ignoreCancelled. Might as well short circuit and validate our assumptions.
+            return
+        }
         val caster = event.caster
         if (caster !is Player) {
             return
@@ -37,6 +42,12 @@ class MagicSpellsListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onSpellTarget(event: SpellTargetEvent) {
+        if (event.isCancelled) {
+            // Apparently we might be receiving a cancelled event despite not opting into
+            // ignoreCancelled. Might as well short circuit and validate our assumptions.
+            return
+        }
+
         val caster = event.caster
         if (caster !is Player) {
             return
@@ -89,6 +100,12 @@ class MagicSpellsListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onSpellTargetLocationEvent(event: SpellTargetLocationEvent) {
+        if (event.isCancelled) {
+            // Apparently we might be receiving a cancelled event despite not opting into
+            // ignoreCancelled. Might as well short circuit and validate our assumptions.
+            return
+        }
+
         if (event.spell !is PulserSpell) {
             return
         }


### PR DESCRIPTION
Somehow it was possible for our `onSpellCast` handler to receive a cancelled event. Since we operate on the assumption that our event handlers are given non-cancelled events, this caused issues when large numbers of passive spells were being un-cancelled.