### PR TITLE
Fix bug where deaths would register twice

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -156,39 +156,29 @@ class Warzone(
             removeEntities()
         }
         if (plugin.hasPlugin("FastAsyncWorldEdit")) {
+            teams.values.forEach { team ->
+                team.resetAttributes(resetTeamScores)
+                team.resetSpawns()
+                team.players.forEach { player ->
+                    respawnPlayer(player)
+                }
+            }
+            resetObjectives()
             if (plugin.isEnabled) {
                 plugin.server.scheduler.runTaskAsynchronously(plugin) { _ ->
                     val start = System.currentTimeMillis()
                     restoreVolume()
                     plugin.logger.info("Warzone volume reset took ${System.currentTimeMillis() - start} ms")
-                    plugin.server.scheduler.runTask(plugin) { _ ->
-                        teams.values.forEach { team ->
-                            team.resetAttributes(resetTeamScores)
-                            team.resetSpawns()
-                            team.players.forEach { player ->
-                                respawnPlayer(player)
-                            }
-                        }
-                        resetObjectives()
-                        state = if (resetTeamScores) {
-                            WarzoneState.IDLING
-                        } else {
-                            WarzoneState.RUNNING
-                        }
+                    state = if (resetTeamScores) {
+                        WarzoneState.IDLING
+                    } else {
+                        WarzoneState.RUNNING
                     }
                 }
             } else {
                 val start = System.currentTimeMillis()
                 restoreVolume()
                 plugin.logger.info("Warzone volume reset took ${System.currentTimeMillis() - start} ms")
-                teams.values.forEach { team ->
-                    team.resetAttributes(resetTeamScores)
-                    team.resetSpawns()
-                    team.players.forEach { player ->
-                        respawnPlayer(player)
-                    }
-                }
-                resetObjectives()
                 state = if (resetTeamScores) {
                     WarzoneState.IDLING
                 } else {

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
@@ -127,7 +127,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
         }
     }
 
-    private fun handleNaturalPlayerDamage(event: EntityDamageByEntityEvent, defender: Player) {
+    private fun handleNaturalPlayerDamage(event: EntityDamageEvent, defender: Player) {
         val defenderInfo = plugin.playerManager.getPlayerInfo(defender) ?: return
         if (defenderInfo.inSpawn) {
             event.isCancelled = true
@@ -201,18 +201,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
         }
 
         val player = event.entity as? Player ?: return
-        val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
-        if (playerInfo.inSpawn) {
-            event.isCancelled = true
-            return
-        }
-
-        if (event.finalDamage < player.health) {
-            return
-        }
-
-        event.isCancelled = true
-        playerInfo.team.warzone.handleNaturalDeath(player, event.cause)
+        handleNaturalPlayerDamage(event, player)
     }
 
     @EventHandler


### PR DESCRIPTION
Since we were respawning players asynchronously, this resulted in damage events that fire rapidly (lava, cacti, etc) causing double kills at the end of a warzone round.