### PR TITLE
Ignore cancelled events

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/listeners/BlockListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/BlockListener.kt
@@ -20,6 +20,8 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockBreak(event: BlockBreakEvent) {
+        if (event.isCancelled) return
+
         val block = event.block
         val player = event.player
         val targetZone = plugin.warzoneManager.getWarzoneByLocation(block.location)
@@ -63,6 +65,8 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockPlace(event: BlockPlaceEvent) {
+        if (event.isCancelled) return
+
         val block = event.block
         val player = event.player
         val targetZone = plugin.warzoneManager.getWarzoneByLocation(block.location)
@@ -92,6 +96,7 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockBurn(event: BlockBurnEvent) {
+        if (event.isCancelled) return
         val block = event.block
         val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
         event.isCancelled = warzone.onBlockBreak(null, block)
@@ -99,6 +104,7 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockIgnite(event: BlockIgniteEvent) {
+        if (event.isCancelled) return
         val block = event.block
         val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
         event.isCancelled = warzone.onBlockBreak(null, block)
@@ -106,6 +112,7 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockSpread(event: BlockSpreadEvent) {
+        if (event.isCancelled) return
         val block = event.block
         val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
         event.isCancelled = warzone.isSpawnBlock(block) || warzone.onBlockBreak(null, block)
@@ -113,6 +120,7 @@ class BlockListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onBlockFromTo(event: BlockFromToEvent) {
+        if (event.isCancelled) return
         val to = event.toBlock
         val warzone = plugin.warzoneManager.getWarzoneByLocation(to.location) ?: return
         event.isCancelled = warzone.isSpawnBlock(to) || warzone.onBlockBreak(null, to)

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
@@ -31,6 +31,8 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onEntityDamageByEntity(event: EntityDamageByEntityEvent) {
+        if (event.isCancelled) return
+
         val defender = event.entity
         val damager = event.damager
 
@@ -172,6 +174,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onEntityExplode(event: EntityExplodeEvent) {
+        if (event.isCancelled) return
         val originalSize = event.blockList().size
         // Prevent blocks that are important to any warzone from being blown up
         event.blockList().removeIf { block ->
@@ -196,9 +199,8 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onEntityDamage(event: EntityDamageEvent) {
-        if (event is EntityDamageByEntityEvent) {
-            return
-        }
+        if (event.isCancelled) return
+        if (event is EntityDamageByEntityEvent) return
 
         val player = event.entity as? Player ?: return
         handleNaturalPlayerDamage(event, player)
@@ -206,6 +208,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onEntityRegainHealth(event: EntityRegainHealthEvent) {
+        if (event.isCancelled) return
         val player = event.entity as? Player ?: return
         plugin.playerManager.getPlayerInfo(player) ?: return
 
@@ -221,6 +224,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onFoodLevelChange(event: FoodLevelChangeEvent) {
+        if (event.isCancelled) return
         val player = event.entity as? Player ?: return
         val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
         if (!playerInfo.team.settings.get(TeamConfigType.HUNGER)) {
@@ -228,7 +232,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerDeath(event: PlayerDeathEvent) {
         val player = event.entity as? Player ?: return
         plugin.playerManager.getPlayerInfo(player) ?: return
@@ -239,6 +243,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPotionSplash(event: PotionSplashEvent) {
+        if (event.isCancelled) return
         val potion = event.potion
         val shooter = potion.shooter
 
@@ -312,6 +317,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onEntityPickupItem(event: EntityPickupItemEvent) {
+        if (event.isCancelled) { return }
         val player = event.entity as? Player ?: return
         val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
         val warzone = playerInfo.team.warzone
@@ -324,6 +330,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onEntityRegainHealthEvent(event: EntityRegainHealthEvent) {
+        if (event.isCancelled) { return }
         val player = event.entity as? Player ?: return
         plugin.playerManager.getPlayerInfo(player) ?: return
         if (event.regainReason == EntityRegainHealthEvent.RegainReason.REGEN) {
@@ -333,6 +340,7 @@ class EntityListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onEntityChangeBlockEvent(event: EntityChangeBlockEvent) {
+        if (event.isCancelled) { return }
         val block = event.block
         if (event.entityType != EntityType.FALLING_BLOCK) {
             return

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
@@ -42,6 +42,8 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerTeleport(event: PlayerTeleportEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
         val playerInfo = plugin.playerManager.getParticipantInfo(player) ?: return
 
@@ -70,6 +72,8 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPlayerDamageItem(event: PlayerItemDamageEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
         plugin.playerManager.getPlayerInfo(player) ?: return
 
@@ -78,6 +82,8 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerMove(event: PlayerMoveEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
         val to = event.to ?: return
         val from = event.from
@@ -146,6 +152,8 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPlayerDropItem(event: PlayerDropItemEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
         val playerInfo = plugin.playerManager.getPlayerInfo(player) ?: return
         val warzone = playerInfo.team.warzone
@@ -173,6 +181,7 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPlayerToggleSneakEvent(event: PlayerToggleSneakEvent) {
+        if (event.isCancelled) return
         if (!event.isSneaking) {
             // Only handle the initial sneak, not release
             return
@@ -222,6 +231,7 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPlayerBucketEmpty(event: PlayerBucketEmptyEvent) {
+        if (event.isCancelled) return
         val block = event.blockClicked
         val warzone = plugin.warzoneManager.getWarzoneByLocation(block.location) ?: return
         event.isCancelled = warzone.isSpawnBlock(block) || warzone.onBlockPlace(event.player, block)
@@ -245,6 +255,8 @@ class PlayerListener(val plugin: WarPlus) : Listener {
 
     @EventHandler
     fun onPlayerPickupArrowEvent(event: PlayerPickupArrowEvent) {
+        if (event.isCancelled) return
+
         // Allow picked up arrows to be renamed by the plugin
         val player = event.player
         plugin.playerManager.getPlayerInfo(player) ?: return


### PR DESCRIPTION
We really shouldn't be getting cancelled events since we're not opting into `ignoreCancelled` but this behavior sometimes happens anyways