### PR TITLE
Allow spawns to have increased protection against enemies

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/WarPlus.kt
@@ -64,6 +64,7 @@ val DEFAULT_WARZONE_CONFIG by lazy {
     config[WarzoneConfigType.REMOVE_ENTITIES_ON_RESET.path] = WarzoneConfigType.REMOVE_ENTITIES_ON_RESET.default
     config[WarzoneConfigType.RESET_ON_EMPTY.path] = WarzoneConfigType.RESET_ON_EMPTY.default
     config[WarzoneConfigType.CAPTURE_POINT_TIME.path] = WarzoneConfigType.CAPTURE_POINT_TIME.default
+    config[WarzoneConfigType.SPAWN_PROTECTION_RADIUS.path] = WarzoneConfigType.SPAWN_PROTECTION_RADIUS.default
     config
 }
 

--- a/src/main/kotlin/com/github/james9909/warplus/config/WarzoneConfigType.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/config/WarzoneConfigType.kt
@@ -15,5 +15,6 @@ class WarzoneConfigType private constructor() {
         val REMOVE_ENTITIES_ON_RESET = booleanKey("remove-entities-on-reset", true)
         val RESET_ON_EMPTY = booleanKey("reset-on-empty", true)
         val CAPTURE_POINT_TIME = integerKey("capture-point-time", 20)
+        val SPAWN_PROTECTION_RADIUS = integerKey("spawn-protection-radius", 10)
     }
 }

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/EntityListener.kt
@@ -182,11 +182,9 @@ class EntityListener(val plugin: WarPlus) : Listener {
                 warzone.contains(block.location) &&
                 (
                     warzone.state != WarzoneState.RUNNING ||
-                    warzone.isSpawnBlock(block) ||
                     !warzone.warzoneSettings.get(WarzoneConfigType.CAN_BREAK_BLOCKS) ||
-                    warzone.objectives.values.any { objective ->
-                        objective.handleBlockBreak(null, block)
-                    }
+                    warzone.isSpawnBlock(block) ||
+                    warzone.onBlockBreak(null, block)
                 )
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,8 @@ warzone:
       monument-heal-chance: 0.2
       remove-entities-on-reset: true
       reset-on-empty: true
+      capture-point-time: 20
+      spawn-protection-radius: 10
 team:
   default:
     config:


### PR DESCRIPTION
Modifications to block around a team's spawn can be prevented if the actor is not on that team. This can protect players from being locked in their spawn by malicious actors.