### PR TITLE
Fix check for rewarding MVPs

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -523,13 +523,13 @@ class Warzone(
                 }
 
                 // Handle mvp rewards separately
-                if (player == mostKills) {
+                if (player.uniqueId == mostKills?.first?.uniqueId) {
                     reward.giveMvpReward(player)
                 }
-                if (player == mostHeals) {
+                if (player.uniqueId == mostHeals?.first?.uniqueId) {
                     reward.giveMvpReward(player)
                 }
-                if (player == mostPoints) {
+                if (player.uniqueId == mostPoints?.first?.uniqueId) {
                     reward.giveMvpReward(player)
                 }
 


### PR DESCRIPTION
When we changed MVPs to be per-team in 430e33431c442127b910d31b0cb5fb5e67edfc65, we forgot to update the equality check for rewarding certain players, causing nobody to receive their MVP rewards.