### PR TITLE
Limit spectators to the same commands as regular players

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/PlayerListener.kt
@@ -238,7 +238,7 @@ class PlayerListener(val plugin: WarPlus) : Listener {
     fun onPlayerCommandPreprocess(event: PlayerCommandPreprocessEvent) {
         if (event.isCancelled) return
         val player = event.player
-        plugin.playerManager.getPlayerInfo(player.uniqueId) ?: return
+        plugin.playerManager.getParticipantInfo(player.uniqueId) ?: return
 
         // Admins can execute any command
         if (player.hasPermission("warplus.admin")) return


### PR DESCRIPTION
Since `getPlayerInfo` only returns non-null for an actual warzone participant, we weren't processing commands for spectators.