### PR TITLE
Remove unnecessary mask tests

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/Warzone.kt
@@ -1144,7 +1144,6 @@ class Warzone(
         statTracker?.warzoneId = id
 
         stopObjectives()
-        state = WarzoneState.IDLING
     }
 
     private fun sendFinalResults(

--- a/src/main/kotlin/com/github/james9909/warplus/command/player/JoinWarzoneCommand.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/command/player/JoinWarzoneCommand.kt
@@ -39,6 +39,10 @@ class JoinWarzoneCommand : PlayerCommand() {
             plugin.playerManager.sendMessage(sender, Message.WARZONE_EDITING)
             return true
         }
+        if (warzone.state == WarzoneState.RESETTING) {
+            plugin.playerManager.sendMessage(sender, "This warzone is currently resetting!")
+            return true
+        }
 
         warzone.addPlayer(sender)
         return true

--- a/src/main/kotlin/com/github/james9909/warplus/listeners/WorldEditListener.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/listeners/WorldEditListener.kt
@@ -2,6 +2,7 @@ package com.github.james9909.warplus.listeners
 
 import com.github.james9909.warplus.WarPlus
 import com.github.james9909.warplus.WarzoneState
+import com.sk89q.worldedit.EditSession
 import com.sk89q.worldedit.bukkit.BukkitAdapter
 import com.sk89q.worldedit.event.extent.EditSessionEvent
 import com.sk89q.worldedit.extent.MaskingExtent
@@ -32,7 +33,7 @@ class FaweListener(private val plugin: WarPlus) {
     @Subscribe
     fun onEditSessionEvent(event: EditSessionEvent) {
         val world = event.world
-        if (world != null) {
+        if (world != null && event.stage == EditSession.Stage.BEFORE_CHANGE) {
             event.extent.addProcessor(
                 MaskingExtent(
                     event.extent,


### PR DESCRIPTION
`EditSessionEvent`s have 3 stages and we were running our structure protection mask on all 3 when we only need to run it once.