### PR TITLE
Allow structures to explicitly set blocks as AIR

### DIFF
--- a/src/main/kotlin/com/github/james9909/warplus/structures/AbstractStructure.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/structures/AbstractStructure.kt
@@ -98,7 +98,8 @@ abstract class AbstractStructure(val plugin: WarPlus, val origin: Location) {
                 val blockYZ = blockY.getRelative(orientation.back.toBlockFace(), zOffset)
                 row.forEachIndexed { xOffset, material ->
                     val blockXYZ = blockYZ.getRelative(orientation.right.toBlockFace(), xOffset)
-                    if (material != Material.AIR) {
+                    if (material != Material.FIRE) {
+                        // Material.FIRE acts as NULL due to pains with Kotlin's type inferencing
                         blockXYZ.type = material
                     }
                 }

--- a/src/main/kotlin/com/github/james9909/warplus/structures/CapturePointStructure.kt
+++ b/src/main/kotlin/com/github/james9909/warplus/structures/CapturePointStructure.kt
@@ -193,18 +193,18 @@ class CapturePointStructure(
     override fun getStructure(): Array<Array<Array<Material>>> {
         val obsidian = Material.OBSIDIAN
         val stone = Material.SMOOTH_STONE
-        val air = Material.AIR
+        val none = Material.FIRE
         return arrayOf(
             arrayOf(
-                arrayOf(air, air, air, air, obsidian, air, air, air, air),
-                arrayOf(air, air, obsidian, obsidian, obsidian, obsidian, obsidian, air, air),
-                arrayOf(air, obsidian, obsidian, stone, stone, stone, obsidian, obsidian, air),
-                arrayOf(air, obsidian, stone, stone, stone, stone, stone, obsidian, air),
+                arrayOf(none, none, none, none, obsidian, none, none, none, none),
+                arrayOf(none, none, obsidian, obsidian, obsidian, obsidian, obsidian, none, none),
+                arrayOf(none, obsidian, obsidian, stone, stone, stone, obsidian, obsidian, none),
+                arrayOf(none, obsidian, stone, stone, stone, stone, stone, obsidian, none),
                 arrayOf(obsidian, obsidian, stone, stone, stone, stone, stone, obsidian, obsidian),
-                arrayOf(air, obsidian, stone, stone, stone, stone, stone, obsidian, air),
-                arrayOf(air, obsidian, obsidian, stone, stone, stone, obsidian, obsidian, air),
-                arrayOf(air, air, obsidian, obsidian, obsidian, obsidian, obsidian, air, air),
-                arrayOf(air, air, air, air, obsidian, air, air, air, air)
+                arrayOf(none, obsidian, stone, stone, stone, stone, stone, obsidian, none),
+                arrayOf(none, obsidian, obsidian, stone, stone, stone, obsidian, obsidian, none),
+                arrayOf(none, none, obsidian, obsidian, obsidian, obsidian, obsidian, none, none),
+                arrayOf(none, none, none, none, obsidian, none, none, none, none)
             )
         )
     }


### PR DESCRIPTION
Instead of using `Material.AIR` as null, we use `Material.FIRE` since setting structures to be `Array<Array<Array<Material?>>>` seems unwieldy in Kotlin.